### PR TITLE
Evitar usar nombres de clases

### DIFF
--- a/themes/droda/assets/css/main.css
+++ b/themes/droda/assets/css/main.css
@@ -151,7 +151,7 @@ nav ul {
    overflow: hidden;
 }
 
-.hover {
+.nav-items {
    padding-bottom: .15em;
    background: var(--navLinkColor), var(--navLinkColor);
    background-size: .3em .1em;
@@ -160,7 +160,7 @@ nav ul {
    transition: .3s linear, background-size .3s .2s linear;
 }
 
-.hover:hover {
+.nav-items:hover {
    background-size: 50% .1em;
    background-position: 10% 100%, 90% 100%;
 }

--- a/themes/droda/assets/css/main.css
+++ b/themes/droda/assets/css/main.css
@@ -293,7 +293,7 @@ footer {
    }
 
    aside {
-      display: none;
+      display: none !important;
    }
    
    nav button, aside li a {

--- a/themes/droda/assets/css/main.css
+++ b/themes/droda/assets/css/main.css
@@ -25,7 +25,7 @@
    --bgColorBlue: #1b6694;
    --bgColorSalamandra: rgb(236, 162, 143);
    --globalScale: 1;
-   
+   --navLinkColor: linear-gradient(#1482c8 0 0);
 }
 
 h1 {
@@ -105,7 +105,7 @@ aside {
    overflow: auto;
 }
 
-aside .item {
+aside > div, li {
    color: var(--bgColorLight);
    display: flex;
    flex-flow: column nowrap;
@@ -152,10 +152,8 @@ nav ul {
 }
 
 .hover {
-   --c:linear-gradient(#1482c8 0 0); /* update the color here */
-
    padding-bottom: .15em;
-   background: var(--c), var(--c);
+   background: var(--navLinkColor), var(--navLinkColor);
    background-size: .3em .1em;
    background-position:50% 100%;
    background-repeat: no-repeat;

--- a/themes/droda/layouts/partials/aside.html
+++ b/themes/droda/layouts/partials/aside.html
@@ -6,6 +6,6 @@
   </div>
   {{ end }}
   {{ range .Site.Sections }}
-    <li><a class="hover" href="{{ .Permalink }}">{{ .Title }}</a></li>
+    <li><a class="nav-items" href="{{ .Permalink }}">{{ .Title }}</a></li>
   {{ end }}
 </aside>

--- a/themes/droda/layouts/partials/aside.html
+++ b/themes/droda/layouts/partials/aside.html
@@ -1,11 +1,11 @@
 {{ "<!-- Bloque parcial para el aside -->" | safeHTML }}
 <aside>
   {{ range .Site.Menus.main }}
-  <div class="item">
+  <div>
     {{ .Pre }}<a href="{{ .URL }}" title="{{ .Identifier }}" target="_blank">{{ .Name }}</a>
   </div>
   {{ end }}
   {{ range .Site.Sections }}
-    <li class="item"><a class="hover" href="{{ .Permalink }}">{{ .Title }}</a></li>
+    <li><a class="hover" href="{{ .Permalink }}">{{ .Title }}</a></li>
   {{ end }}
 </aside>

--- a/themes/droda/layouts/partials/navbar.html
+++ b/themes/droda/layouts/partials/navbar.html
@@ -1,11 +1,11 @@
 {{ "<!-- Partial block for navbar -->" | safeHTML }}
 <nav>
   {{ with .Site.GetPage "home" }}
-  <div><img src="{{ .Params.homeIcon | absURL }}" alt=""><a class="hover" href="{{ .Permalink }}">{{ .Title }}</a></div>
+  <div><img src="{{ .Params.homeIcon | absURL }}" alt=""><a class="nav-items" href="{{ .Permalink }}">{{ .Title }}</a></div>
   {{ end }}
   <ul>
   {{ range .Site.Sections }}
-  <li><a class="hover" href="{{ .Permalink }}">{{ .Title }}</a></li>
+  <li><a class="nav-items" href="{{ .Permalink }}">{{ .Title }}</a></li>
   {{ end }}
   </ul>
   <button data-visible="false"></button>


### PR DESCRIPTION
La idea general del sitio es el aprendizaje de html y css lo más semántico posible. El uso de clases ayuda a que el desarrollador no se preocupe demasiado por la semántica, por lo que si lo evitamos, la semántica termina siendo preponderante.